### PR TITLE
Add DUPLICATE_LOG_LEVEL setting to control log output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   # python import sorting - will amend files
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.9.3
+    rev: v5.10.1
     hooks:
       - id: isort
 
   # python code formatting - will amend files
   - repo: https://github.com/ambv/black
-    rev: 21.8b0
+    rev: 22.10.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.25.0
+    rev: v3.1.0
     hooks:
       - id: pyupgrade
 
@@ -30,7 +30,7 @@ repos:
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.982
     hooks:
       - id: mypy
         additional_dependencies:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,6 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## 1.1 [Unreleased]
+
+* Added support for controlling logging duplicates (#20)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-user-visit"
-version = "1.0"
+version = "1.1"
 description = "Django app used to track user visits."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -68,7 +68,6 @@ def test_save_user_visit__duplicate__log_levels(mock_logger):
     assert mock_logger.debug.call_count == 1
 
 
-
 @pytest.mark.django_db
 class TestUserVisitMiddleware:
     """RequestTokenMiddleware tests."""

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,6 @@ commands =
 [testenv:lint]
 description = Python source code linting (flake8, bandit, pydocstyle)
 deps =
-    # pinned because of an issue in flake8-bandit with 1.7.3
-    bandit==1.7.2
     flake8
     flake8-bandit
     flake8-docstrings

--- a/user_visit/middleware.py
+++ b/user_visit/middleware.py
@@ -8,17 +8,20 @@ from django.utils import timezone
 
 from user_visit.models import UserVisit
 
-from .settings import RECORDING_BYPASS, RECORDING_DISABLED
+from .settings import RECORDING_BYPASS, RECORDING_DISABLED, DUPLICATE_LOG_LEVEL
 
 logger = logging.getLogger(__name__)
 
 
+@django.db.transaction.atomic
 def save_user_visit(user_visit: UserVisit) -> None:
     """Save the user visit and handle db.IntegrityError."""
     try:
         user_visit.save()
     except django.db.IntegrityError:
-        logger.warning("Error saving user visit (hash='%s')", user_visit.hash)
+        getattr(logger, DUPLICATE_LOG_LEVEL)(
+            "Error saving user visit (hash='%s')", user_visit.hash
+        )
 
 
 class UserVisitMiddleware:

--- a/user_visit/middleware.py
+++ b/user_visit/middleware.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 
 from user_visit.models import UserVisit
 
-from .settings import RECORDING_BYPASS, RECORDING_DISABLED, DUPLICATE_LOG_LEVEL
+from .settings import DUPLICATE_LOG_LEVEL, RECORDING_BYPASS, RECORDING_DISABLED
 
 logger = logging.getLogger(__name__)
 

--- a/user_visit/models.py
+++ b/user_visit/models.py
@@ -131,7 +131,7 @@ class UserVisit(models.Model):
     # see https://github.com/python/typeshed/issues/2928 re. return type
     def md5(self) -> hashlib._Hash:
         """Generate MD5 hash used to identify duplicate visits."""
-        h = hashlib.md5(str(self.user.id).encode())  # noqa: S303
+        h = hashlib.md5(str(self.user.id).encode())  # noqa: S303, S324
         h.update(self.date.isoformat().encode())
         h.update(self.session_key.encode())
         h.update(self.remote_addr.encode())

--- a/user_visit/settings.py
+++ b/user_visit/settings.py
@@ -1,6 +1,5 @@
 from os import getenv
 from typing import Any, Callable
-
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpRequest
@@ -36,3 +35,11 @@ REQUEST_CONTEXT_ENCODER = getattr(
 # must be a Callable that takes a HttpRequest arg and returns a bool -
 # if True then the recording is bypassed.
 RECORDING_BYPASS = getattr(settings, "USER_VISIT_RECORDING_BYPASS", lambda r: False)
+
+
+# The log level to use when logging duplicate hashes. This is WARNING by
+# default, but if it's noisy you can turn this down by setting this
+# value. Must be one of "debug", "info", "warning", "error"
+DUPLICATE_LOG_LEVEL: str = getattr(
+    settings, "USER_VISIT_DUPLICATE_LOG_LEVEL", "warning"
+).lower()

--- a/user_visit/settings.py
+++ b/user_visit/settings.py
@@ -1,5 +1,6 @@
 from os import getenv
 from typing import Any, Callable
+
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpRequest


### PR DESCRIPTION
Solves #20 

Adds a new setting `USER_VISIT_DUPLICATE_LOG_LEVEL` to control the
level at which duplicates are logged. By default this is "warning",
but if you are using an external error management service like
Sentry this can be noisy. 

