### PR TITLE
Add Python 3.11, drop Python 3.7, Django 3.0, 3.1

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,18 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toxenv: [fmt,lint,mypy]
+        toxenv: [fmt, lint, mypy, checks]
     env:
       TOXENV: ${{ matrix.toxenv }}
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v1
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install and run tox
         run: |
@@ -37,18 +37,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10", "3.11"]
-        django: [32,41,main]
+        python: ["3.8", "3.11"]
+        django: ["32", "41", "main"]
 
     env:
       TOXENV: py${{ matrix.python }}-django${{ matrix.django }}
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,28 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10"]
-        django: [32,40,main]
+        python: ["3.10", "3.11"]
+        django: [32,41,main]
 
     env:
       TOXENV: py${{ matrix.python }}-django${{ matrix.django }}
-
-    # services:
-    #   postgres:
-    #     image: postgres:12
-    #     env:
-    #       POSTGRES_USER: postgres
-    #       POSTGRES_PASSWORD: postgres
-    #       POSTGRES_DB: onfido
-    #       # Set health checks to wait until postgres has started
-    #     options: >-
-    #       --health-cmd pg_isready
-    #       --health-interval 10s
-    #       --health-timeout 5s
-    #       --health-retries 5
-    #     ports:
-    #       # Maps tcp port 5432 on service container to the host
-    #       - 5432:5432
 
     steps:
       - name: Check out the repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: black
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: pyupgrade
 
@@ -33,8 +33,6 @@ repos:
     rev: v0.982
     hooks:
       - id: mypy
-        additional_dependencies:
-          - types-geoip2
         args:
           - --disallow-untyped-defs
           - --disallow-incomplete-defs

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2.0 [Unreleased]
+
+* Drop Python 3.7
+* Add Python 3.11
+* Drop Django 3.0, 3.1
+* Add Django 4.1
+
 ## 1.1 [Unreleased]
 
 * Added support for controlling logging duplicates (#20)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 yunojuno
+Copyright (c) 2022 yunojuno
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,10 +4,7 @@ Django app for recording daily user visits
 
 #### Compatibility
 
-This library uses the `__future__.annotations` import for postponed evaluation of annotations.
-As a result it supports Python 3.7 and above only.
-
-It supports Django 2.2 and above.
+This pibrary supports Python 3.8+ and Django 3.2+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Django app for recording daily user visits
 
 #### Compatibility
 
-This pibrary supports Python 3.8+ and Django 3.2+
+This package supports Python 3.8+ and Django 3.2+
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-user-visit"
-version = "1.1"
+version = "2.0.beta0"
 description = "Django app used to track user visits."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -12,27 +12,26 @@ documentation = "https://github.com/yunojuno/django-user-visit"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
     "Framework :: Django :: 4.0",
+    "Framework :: Django :: 4.1",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 packages = [{ include = "user_visit" }]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-django = "^3.1 || ^4.0"
+python = "^3.8"
+django = "^3.2 || ^4.0"
 user-agents = "^2.1"
 
 [tool.poetry.dev-dependencies]
-bandit = "1.7.2"
-black = {version = "*", allow-prereleases = true}
+black = "*"
 coverage = "*"
 flake8 = "*"
 flake8-bandit = "*"

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -40,6 +40,7 @@ TEMPLATES = [
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
+                "django.template.context_processors.request",
                 "django.contrib.messages.context_processors.messages",
                 "django.contrib.auth.context_processors.auth",
             ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = fmt, lint, mypy, py{3.8,3.9,3.10,3.11}-django{32,40,41,main}
+envlist = fmt, lint, mypy, checks, py{3.8,3.9,3.10,3.11}-django{32,40,41,main}
 
 [testenv]
 whitelist_externals = poetry
@@ -17,6 +17,13 @@ deps =
 
 commands =
     pytest --cov=user_visit tests/
+
+[testenv:checks]
+description = Django system checks and missing migrations
+deps = Django
+commands =
+    python manage.py check --fail-level WARNING
+    python manage.py makemigrations --dry-run --check --verbosity 3
 
 [testenv:fmt]
 description = Python source code formatting (isort, black)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = fmt, lint, mypy, py{3.7,3.8,3.9,3.10}-django{31,32,40,main}
+envlist = fmt, lint, mypy, py{3.8,3.9,3.10,3.11}-django{32,40,41,main}
 
 [testenv]
 whitelist_externals = poetry
@@ -10,9 +10,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django{22,30}: psycopg2-binary
-    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =

--- a/user_visit/__init__.py
+++ b/user_visit/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "user_visit.apps.UserVisitAppConfig"

--- a/user_visit/apps.py
+++ b/user_visit/apps.py
@@ -5,3 +5,4 @@ class UserVisitAppConfig(AppConfig):
 
     name = "user_visit"
     verbose_name = "User visit log"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
Fixes #22 

---

* Add Python 3.11 to CI / PyPI classifiers
* Update GH Actions
* Add CHANGELOG
* Update LICENSE