### PR TITLE
Make use of self.model for easier customization

### DIFF
--- a/user_visit/models.py
+++ b/user_visit/models.py
@@ -32,8 +32,8 @@ class UserVisitManager(models.Manager):
     """Custom model manager for UserVisit objects."""
 
     def build(self, request: HttpRequest, timestamp: datetime.datetime) -> UserVisit:
-        """Build a new UserVisit object from a request, without saving it."""
-        uv = UserVisit(
+        """Build a new Model object from a request, without saving it."""
+        uv = self.model(
             user=request.user,
             timestamp=timestamp,
             session_key=request.session.session_key,


### PR DESCRIPTION
I want to use a model that inherits from the UserVisit model, so I change the reference from the Manager class to `self.model` instead of UserVisit.

ref: https://docs.djangoproject.com/en/4.2/topics/db/managers/#custom-managers