### PR TITLE
chore: Use `ruff check` instead of `ruff`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ deps =
     ruff
 
 commands =
-    ruff user_visit
+    ruff check user_visit
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
Ruff changed from "ruff" to "ruff check" starting from version 0.5.0.

ref: https://github.com/astral-sh/ruff/blob/b9c8113a8a80a464fd042f290553817d8024fdfc/CHANGELOG.md#removals