### PR TITLE
Fix deprecation warning for poetry.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ python = "^3.8"
 django = "^3.2 || ^4.0 || ^5.0"
 user-agents = "^2.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = {version = "*", allow-prereleases = true}
 coverage = "*"
 freezegun = "*"


### PR DESCRIPTION
Got this while running `poetry update` in a project using django-user-visit.