### PR TITLE
Django 5.2 updates

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -60,16 +60,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        django: ["32", "42", "50", "main"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
+        django: ["42", "50", "51", "52", "main"]
         exclude:
-          - python: "3.8"
-            django: "50"
-          - python: "3.8"
+          - python: "3.10"
             django: "main"
-          - python: "3.9"
-            django: "50"
-          - python: "3.9"
+          - python: "3.11"
             django: "main"
 
     env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,12 @@
 repos:
-  # python code formatting - will amend files
-  - repo: https://github.com/ambv/black
-    rev: 23.10.1
-    hooks:
-      - id: black
-
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  # python code formatting and linting - will amend files
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: "v0.1.4"
+    rev: "v0.11.13"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,6 @@
 line-length = 88
+
+[lint]
 ignore = [
     "D100",  # Missing docstring in public module
     "D101",  # Missing docstring in public class
@@ -34,13 +36,13 @@ select = [
     "W",  # pycodestype (warnings)
 ]
 
-[isort]
+[lint.isort]
 combine-as-imports = true
 
-[mccabe]
+[lint.mccabe]
 max-complexity = 8
 
-[per-file-ignores]
+[lint.per-file-ignores]
 "*tests/*" = [
     "D205",  # 1 blank line required between summary line and description
     "D400",  # First line should end with a period

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2.1
+
+* Add Django 5.1 and 5.2 support
+* Add Python 3.13 support
+* Drop support for Django < 4.2 (Django 3.2, 4.0, 4.1)
+* Updated minimum Python version requirement to 3.10
+* Updated ruff configuration to use modern syntax
+* Update GitHub workflows to test Django main branch only with Python 3.12+
+
 ## 2.0
 
 **BREAKING CHANGES**

--- a/README.md
+++ b/README.md
@@ -4,34 +4,31 @@ Django app for recording daily user visits
 
 #### Compatibility
 
-This package supports Python 3.8 and above and Django 3.2 and above.
+This package supports Python 3.10 and above and Django 4.2 and above.
 
 ## Upgrading from v1 to v2
 
-v2 added three new denormalised fields extracted from the User Agent
-string - device, os, browser - to make it easier to analyse directly
-in the database.
+v2 added three new denormalised fields extracted from the User Agent string - device, os, browser -
+to make it easier to analyse directly in the database.
 
-If you want to backfill historical data you will need to run the
-management command `update_user_visit_user_agent_data` after the
-upgrade.
+If you want to backfill historical data you will need to run the management command
+`update_user_visit_user_agent_data` after the upgrade.
 
 ---
 
-This app consists of middleware to record user visits, and a single
-`UserVisit` model to capture that data.
+This app consists of middleware to record user visits, and a single `UserVisit` model to capture
+that data.
 
-The principal behind this is _not_ to record every single request made
-by a user. It is to record each daily visit to a site.
+The principal behind this is _not_ to record every single request made by a user. It is to record
+each daily visit to a site.
 
-The one additional factor is that it will record a single daily visit
-per session / device / ip combination. This means that if a user visits
-a site multiple times from the same location / same device, without
-logging out, then they will be recorded once. If the same user logs in
-from a different device, IP address, then they will be recorded again.
+The one additional factor is that it will record a single daily visit per session / device / ip
+combination. This means that if a user visits a site multiple times from the same location / same
+device, without logging out, then they will be recorded once. If the same user logs in from a
+different device, IP address, then they will be recorded again.
 
-The goal is to record unique daily visits per user 'context' ( where
-context is the location / device combo).
+The goal is to record unique daily visits per user 'context' ( where context is the location /
+device combo).
 
 Admin list view:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-user-visit"
-version = "2.0"
+version = "2.1"
 description = "Django app used to track user visits."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
@@ -12,29 +12,26 @@ documentation = "https://github.com/yunojuno/django-user-visit"
 classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 packages = [{ include = "user_visit" }]
 
 [tool.poetry.dependencies]
-python = "^3.8"
-django = "^3.2 || ^4.0 || ^5.0"
+python = "^3.10"
+django = "^4.2 || ^5.0"
 user-agents = "^2.1"
 
-[tool.poetry.dev-dependencies]
-black = {version = "*", allow-prereleases = true}
+[tool.poetry.group.dev.dependencies]
 coverage = "*"
 freezegun = "*"
 mypy = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,12 @@ isolated_build = True
 envlist =
     fmt, lint, mypy,
     django-checks,
-    ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{38,39,310}
-    django40-py{38,39,310}
-    django41-py{38,39,310,311}
-    django42-py{38,39,310,311}
+    ; https://docs.djangoproject.com/en/5.2/releases/
+    django42-py{310,311,312}
     django50-py{310,311,312}
-    djangomain-py{311,312}
+    django51-py{311,312,313}
+    django52-py{311,312,313}
+    djangomain-py{312,313}
 
 [testenv]
 deps =
@@ -18,11 +17,10 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
-    django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django50: Django>=5.0,<5.1
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =
@@ -36,12 +34,12 @@ commands =
     python manage.py makemigrations --dry-run --check --verbosity 3
 
 [testenv:fmt]
-description = Python source code formatting (black)
+description = Python source code formatting (ruff)
 deps =
-    black
+    ruff
 
 commands =
-    black --check user_visit
+    ruff format --check user_visit
 
 [testenv:lint]
 description = Python source code linting (ruff)


### PR DESCRIPTION
## 🚀 Add Django 5.2 Support + Development Tooling

This PR updates the project to support Django 5.2 and modernises the development tooling stack by dropping support for older Django versions and consolidate our linting/formatting tools.

### 🔧 Django & Python Version Updates

- **Added support for Django 5.1 and 5.2** to stay current with the latest Django releases
- **Dropped support for Django < 4.2** (removed 3.2, 4.0, 4.1) to focus on supported LTS and recent versions
- **Dropped support for Python < 3.10** and **added Python 3.13 support** to align with current best practices
- **Updated test matrix** in both `tox.ini` and GitHub Actions to reflect new version support
- **Ensured Django main branch testing only runs on Python 3.12+** for better compatibility

### 🛠️ Development Tooling Improvements

- **Replaced Black with Ruff formatting** throughout the entire toolchain for faster, more consistent code formatting
- **Modernized Ruff commands** to use `ruff check` and `ruff format --check` syntax
- **Updated Ruff configuration** to use the modern `[lint]` section format (addresses deprecation warnings)
- **Updated pre-commit hooks** to use latest ruff-pre-commit version (v0.11.13) with integrated formatting
- **Modernised Poetry configuration** to use `[tool.poetry.group.dev.dependencies]` instead of deprecated format

### 🔄 Version Bump

- **Bumped project version from 2.0 to 2.1**