### PR TITLE
Feat: Add async middleware support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 node_modules
 poetry.lock
 test.db
+.idea/
+q

--- a/user_visit/middleware.py
+++ b/user_visit/middleware.py
@@ -1,14 +1,22 @@
+import inspect
 import logging
 import typing
 
 import django.db
+from asgiref.sync import async_to_sync, sync_to_async
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
+from django.utils.decorators import sync_and_async_middleware
 
 from user_visit.models import UserVisit
 
-from .settings import DUPLICATE_LOG_LEVEL, RECORDING_BYPASS, RECORDING_DISABLED
+from .settings import (
+    DUPLICATE_LOG_LEVEL,
+    FORCE_ASYNC,
+    RECORDING_BYPASS,
+    RECORDING_DISABLED,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,23 +32,107 @@ def save_user_visit(user_visit: UserVisit) -> None:
         )
 
 
-class UserVisitMiddleware:
-    """Middleware to record user visits."""
+def _check_recording_bypass(request: HttpRequest) -> bool:
+    """
+    Check the RECORDING_BYPASS setting, handling both sync and async callables.
 
-    def __init__(self, get_response: typing.Callable) -> None:
-        if RECORDING_DISABLED:
-            raise MiddlewareNotUsed("UserVisit recording has been disabled")
-        self.get_response = get_response
+    In the sync context, if RECORDING_BYPASS is an async callable, we need to
+    run it with async_to_sync to get the actual boolean result. Simply calling
+    an async function returns a coroutine object, which is always truthy.
+    """
+    if inspect.iscoroutinefunction(RECORDING_BYPASS):
+        return async_to_sync(RECORDING_BYPASS)(request)
+    return RECORDING_BYPASS(request)
 
-    def __call__(self, request: HttpRequest) -> typing.Optional[HttpResponse]:
-        if request.user.is_anonymous:
-            return self.get_response(request)
 
-        if RECORDING_BYPASS(request):
-            return self.get_response(request)
+async def _check_recording_bypass_async(request: HttpRequest) -> bool:
+    """
+    Check the RECORDING_BYPASS setting asynchronously.
 
-        uv = UserVisit.objects.build(request, timezone.now())
-        if not UserVisit.objects.filter(hash=uv.hash).exists():
-            save_user_visit(uv)
+    Handles both sync and async callables appropriately.
+    """
+    if inspect.iscoroutinefunction(RECORDING_BYPASS):
+        return await RECORDING_BYPASS(request)
+    return RECORDING_BYPASS(request)
 
-        return self.get_response(request)
+
+@sync_and_async_middleware
+def UserVisitMiddleware(get_response: typing.Callable) -> typing.Callable:
+    """Middleware to record user visits.
+
+    Automatically supports both sync and async request/response cycles.
+    When FORCE_ASYNC is True and the middleware is called in sync context
+    (due to legacy sync middleware in the chain), it will use async_to_sync
+    to run async processing logic.
+    """
+    if RECORDING_DISABLED:
+        raise MiddlewareNotUsed("UserVisit recording has been disabled")
+
+    # Check if get_response is async
+    if inspect.iscoroutinefunction(get_response):
+        # ASYNC PATH: Full async middleware
+        async def async_middleware(
+            request: HttpRequest,
+        ) -> typing.Optional[HttpResponse]:
+            await _process_visit_async(request)
+            return await get_response(request)
+
+        return async_middleware
+
+    else:
+        # SYNC PATH: Sync middleware, but may use async internally
+        def sync_middleware(request: HttpRequest) -> typing.Optional[HttpResponse]:
+            if FORCE_ASYNC:
+                # Force async processing in sync context
+                async_to_sync(_process_visit_async)(request)
+            else:
+                # Pure sync processing
+                _process_visit_sync(request)
+
+            return get_response(request)
+
+        return sync_middleware
+
+
+def _process_visit_sync(request: HttpRequest) -> None:
+    if request.user.is_anonymous:
+        return
+
+    if _check_recording_bypass(request):
+        return
+
+    uv = UserVisit.objects.build(request, timezone.now())
+    if not UserVisit.objects.filter(hash=uv.hash).exists():
+        save_user_visit(uv)
+
+
+async def _process_visit_async(request: HttpRequest) -> None:
+    """Asynchronous visit processing.
+
+    Used when:
+    - Middleware is in async context (full async middleware chain), OR
+    - Middleware is in sync context but FORCE_ASYNC is True
+
+    In the latter case, this is called via async_to_sync(), so the async
+    operations are properly handled without blocking.
+    """
+    # Check if user is anonymous
+    is_anonymous = await sync_to_async(lambda: request.user.is_anonymous)()
+    if is_anonymous:
+        return
+
+    # Check recording bypass
+    if await _check_recording_bypass_async(request):
+        return
+
+    # Build the visit object
+    uv = await sync_to_async(UserVisit.objects.build)(request, timezone.now())
+
+    # Check if visit already exists
+    exists = await sync_to_async(
+        lambda: UserVisit.objects.filter(hash=uv.hash).exists()
+    )()
+
+    if not exists:
+        # Save the visit
+        await sync_to_async(save_user_visit)(uv)

--- a/user_visit/settings.py
+++ b/user_visit/settings.py
@@ -44,3 +44,27 @@ RECORDING_BYPASS = getattr(settings, "USER_VISIT_RECORDING_BYPASS", lambda r: Fa
 DUPLICATE_LOG_LEVEL: str = getattr(
     settings, "USER_VISIT_DUPLICATE_LOG_LEVEL", "warning"
 ).lower()
+
+
+# FORCE_ASYNC: Forces async processing even when middleware is called in sync context
+#
+# When True, the middleware will use async_to_sync to run async logic in the sync
+# code path. This is useful when you have legacy sync-only middleware in your chain
+# that prevents Django's ASGI handler from calling the async __acall__ method.
+#
+# When False (default), the middleware will:
+#   - Use pure async logic if called as async (get_response is async)
+#   - Use pure sync logic if called as sync (get_response is sync)
+#
+# Note: This setting has no effect on async request/response cycles - async views
+# and async-capable middleware will always use the async path naturally.
+#
+# Typical use cases:
+#   - Django projects with many legacy sync-only middleware
+#   - ASGI servers (Daphne, Uvicorn) where you want consistent async patterns
+#   - When you're migrating to async and want async patterns even in sync contexts
+#
+# Can be set via:
+#   - Django setting: USER_VISIT_FORCE_ASYNC = True
+#   - Environment variable: USER_VISIT_FORCE_ASYNC=1
+FORCE_ASYNC = _env_or_setting("USER_VISIT_FORCE_ASYNC", False, lambda x: bool(x))


### PR DESCRIPTION
Migrated `UserVisitMiddleware` to use Django's `@sync_and_async_middleware` decorator to add native async support. The middleware now automatically detects and supports both sync and async request/response cycles.

- Added `USER_VISIT_FORCE_ASYNC` [setting](https://github.com/yunojuno/django-user-visit/pull/39/files#diff-0a24c3489c35872c1b822be5930d855a77456922c6a97482c5c0d2f94573e6aaR49) to force async processing in sync contexts. 

Closes #31 